### PR TITLE
fix(TestDataPermission): rename `permission` to `permissionType`

### DIFF
--- a/ksef-client/src/main/java/pl/akmf/ksef/sdk/client/model/testdata/TestDataPermission.java
+++ b/ksef-client/src/main/java/pl/akmf/ksef/sdk/client/model/testdata/TestDataPermission.java
@@ -1,10 +1,12 @@
 package pl.akmf.ksef.sdk.client.model.testdata;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public class TestDataPermission {
     private String description;
+    @JsonProperty("permissionType")
     private PermissionType permission;
 
     public TestDataPermission(String description, PermissionType permission) {


### PR DESCRIPTION
Cheers,

while using the SDK I noticed that my access token only had the `InvoiceRead` permission set, despite adding the additional permissions to my test subject:

```kotlin
   val permissions = listOf(
                TestDataPermission("Invoice read", TestDataPermission.PermissionType.INVOICE_READ),
                TestDataPermission("Invoice write", TestDataPermission.PermissionType.INVOICE_WRITE),
                TestDataPermission("Introspection", TestDataPermission.PermissionType.INTROSPECTION),
                TestDataPermission("Credentials read", TestDataPermission.PermissionType.CREDENTIAL_READ),
                TestDataPermission("Credentials manage", TestDataPermission.PermissionType.CREDENTIAL_MANAGE),
            )
            val permissionRequest = TestDataPermissionRequest(
                TestDataContextIdentifier(TestDataContextIdentifier.ContextIdentifierType.NIP, testCertificate.nip),
                TestDataAuthorizedIdentifier(
                    TestDataAuthorizedIdentifier.TestDataAuthorizedIdentifierType.FINGERPRINT,
                    testCertificate.fingerprint,
                ),
                permissions,
            )
```

The reason was that `TestDataPermission` produced a wrong Json:

```
{
  "contextIdentifier": {
   ...
  },
  "authorizedIdentifier": {
    ...
  },
  "permissions": [
    {
      "description": "Invoice Write",
      "permission": "InvoiceWrite" // <- Should be named `permissionType`
    },
  ]
}
```

But according to the open-api spec it should be `permissionType`: https://api-test.ksef.mf.gov.pl/docs/v2/index.html#tag/Dane-testowe/paths/~1testdata~1permissions/post

I testet it locally and now I can set the permissions.

Sadly, the Ksef API accepts the invalid json.

Kind regards