### PR TITLE
DefaultVerificationLinkService#buildInvoiceVerificationUrl fix

### DIFF
--- a/ksef-client/src/main/java/pl/akmf/ksef/sdk/api/services/DefaultVerificationLinkService.java
+++ b/ksef-client/src/main/java/pl/akmf/ksef/sdk/api/services/DefaultVerificationLinkService.java
@@ -38,9 +38,9 @@ public class DefaultVerificationLinkService implements VerificationLinkService {
         String date = issueDate.format(DateTimeFormatter.ofPattern("dd-MM-yyyy"));
         byte[] invoiceHashBytes = Base64.getDecoder().decode(invoiceHash);
         String invoiceHashUrlEncoded = Base64.getUrlEncoder().withoutPadding().encodeToString(invoiceHashBytes);
-        String apiPath = ksefApiProperties.getBaseUri() + "/" + CLIENT_APP;
+        String qrAppUrl = ksefApiProperties.getQrUri();
 
-        return String.format("%s/invoice/%s/%s/%s", apiPath, nip, date, invoiceHashUrlEncoded);
+        return String.format("%s/invoice/%s/%s/%s", qrAppUrl, nip, date, invoiceHashUrlEncoded);
     }
 
     @Override


### PR DESCRIPTION
With version [3.0.9 of ksef-client-java](https://github.com/CIRFMF/ksef-client-java/commit/19be5ad888ab5fc0d726263e8fd1dfe796afe0cc) url verification format had changed, the format used by this fork no longer works.

This pull request restores the original behavior.
I'm not touching `buildCertificateVerificationUrl` as I'm not familiar with it, and truth be told I don't know how to test it.